### PR TITLE
fix(docker): harden Dockerfile security, nginx headers, and build reproducibility

### DIFF
--- a/.docker/Viewer-v3.x/default.conf.template
+++ b/.docker/Viewer-v3.x/default.conf.template
@@ -2,17 +2,40 @@ server {
   gzip_static  always;
   gzip_proxied expired no-cache no-store private auth;
   gunzip       on;
+  server_tokens off;
   listen ${PORT} default_server;
   listen [::]:${PORT} default_server;
+
+  # Cache hashed static assets aggressively
+  location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+    root /usr/share/nginx/html;
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+    add_header Cross-Origin-Resource-Policy same-origin;
+    add_header X-Content-Type-Options "nosniff" always;
+  }
+
+  # Don't cache index.html or app-config
+  location ~* (index\.html|app-config\.js)$ {
+    root /usr/share/nginx/html;
+    add_header Cache-Control "no-cache, no-store, must-revalidate";
+    add_header Cross-Origin-Resource-Policy same-origin;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    try_files $uri $uri/ ${PUBLIC_URL}index.html;
+  }
+
   location / {
     root   /usr/share/nginx/html;
     index  index.html index.htm;
     try_files $uri $uri/ ${PUBLIC_URL}index.html;
     add_header Cross-Origin-Resource-Policy same-origin;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
   }
   error_page   500 502 503 504  /50x.html;
   location = /50x.html {

--- a/.docker/Viewer-v3.x/default.ssl.conf.template
+++ b/.docker/Viewer-v3.x/default.ssl.conf.template
@@ -1,17 +1,29 @@
 server {
+  gzip_static  always;
+  gzip_proxied expired no-cache no-store private auth;
+  gunzip       on;
+  server_tokens off;
   listen ${SSL_PORT} ssl http2 default_server;
   listen [::]:${SSL_PORT} ssl http2 default_server;
   ssl_certificate /etc/ssl/certs/ssl-certificate.crt;
   ssl_certificate_key /etc/ssl/private/ssl-private-key.key;
+  ssl_protocols TLSv1.2 TLSv1.3;
+  ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+  ssl_prefer_server_ciphers off;
+  ssl_session_timeout 1d;
+  ssl_session_cache shared:SSL:10m;
+  ssl_session_tickets off;
+
   location / {
     root   /usr/share/nginx/html;
     index  index.html index.htm;
     try_files $uri $uri/ /index.html;
     add_header Cross-Origin-Resource-Policy same-origin;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
   }
   error_page   500 502 503 504  /50x.html;
   location = /50x.html {

--- a/.docker/Viewer-v3.x/entrypoint.sh
+++ b/.docker/Viewer-v3.x/entrypoint.sh
@@ -17,9 +17,8 @@ fi
 if [ -f /usr/share/nginx/html${PUBLIC_URL}app-config.js ]; then
   if [ -s /usr/share/nginx/html${PUBLIC_URL}app-config.js ]; then
     echo "Detected non-empty app-config.js. Ensuring .gz file is updated..."
-    rm -f /usr/share/nginx/html${PUBLIC_URL}app-config.js.gz
-    gzip /usr/share/nginx/html${PUBLIC_URL}app-config.js
-    touch /usr/share/nginx/html${PUBLIC_URL}app-config.js
+    rm -f /usr/share/nginx/html"${PUBLIC_URL}"app-config.js.gz
+    gzip -k /usr/share/nginx/html"${PUBLIC_URL}"app-config.js
     echo "Compressed app-config.js to app-config.js.gz"
   else
     echo "app-config.js is empty. Skipping compression."

--- a/.docker/compressDist.sh
+++ b/.docker/compressDist.sh
@@ -1,4 +1,5 @@
-find platform/app/dist -name "*.js" -exec gzip -9 "{}" \; -exec touch "{}" \;
-find platform/app/dist -name "*.map" -exec gzip -9 "{}" \; -exec touch "{}" \;
-find platform/app/dist -name "*.css" -exec gzip -9 "{}" \; -exec touch "{}" \;
-find platform/app/dist -name "*.svg" -exec gzip -9 "{}" \; -exec touch "{}" \;
+find platform/app/dist -name "*.js" -exec gzip -9 -k "{}" \;
+find platform/app/dist -name "*.map" -exec gzip -9 -k "{}" \;
+find platform/app/dist -name "*.css" -exec gzip -9 -k "{}" \;
+find platform/app/dist -name "*.svg" -exec gzip -9 -k "{}" \;
+find platform/app/dist -name "*.html" -exec gzip -9 -k "{}" \;

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,37 +20,16 @@
 #
 
 
-# syntax=docker/dockerfile:1.7-labs
-# This dockerfile is used to publish the `ohif/app` image on dockerhub.
-#
-# It's a good example of how to build our static application and package it
-# with a web server capable of hosting it as static content.
-#
-# docker build
-# --------------
-# If you would like to use this dockerfile to build and tag an image, make sure
-# you set the context to the project's root directory:
-# https://docs.docker.com/engine/reference/commandline/build/
-#
-#
-# SUMMARY
-# --------------
-# This dockerfile is used as an input for a second stage to make things run faster.
-#
-
-
 # Stage 1: Build the application
 # docker build -t ohif/viewer:latest .
-# Copy Files
-FROM node:20.18.1-slim as builder
+FROM node:20.18.1-slim@sha256:b2c8e0eb8a6aeeae33b2711f8f516003e27ee45804e270468d937b3214f2f0cc AS builder
 
-RUN apt-get update && apt-get install -y build-essential python3
-
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential python3 \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /usr/src/app
 WORKDIR /usr/src/app
-RUN npm install -g bun@1.2.23
-RUN npm install -g lerna@7.4.2
+RUN npm install -g bun@1.2.23 lerna@7.4.2
 ENV PATH=/usr/src/app/node_modules/.bin:$PATH
 
 # Do an initial install and then a final install
@@ -58,15 +37,14 @@ COPY package.json yarn.lock preinstall.js lerna.json ./
 COPY --parents ./addOns/package.json ./addOns/*/*/package.json ./extensions/*/package.json ./modes/*/package.json ./platform/*/package.json ./
 # Run the install before copying the rest of the files
 
-RUN bun pm cache rm
-RUN bun install
-RUN bun add ajv@8.12.0
+RUN bun install --frozen-lockfile
 # Copy the local directory
 COPY --link --exclude=yarn.lock --exclude=package.json --exclude=Dockerfile . .
 
 # Build here
 # After install it should hopefully be stable until the local directory changes
-ENV QUICK_BUILD true
+ARG QUICK_BUILD=false
+ENV QUICK_BUILD=${QUICK_BUILD}
 # ENV GENERATE_SOURCEMAP=false
 ARG APP_CONFIG=config/default.js
 ARG PUBLIC_URL=/
@@ -79,9 +57,9 @@ RUN bun run build
 RUN chmod u+x .docker/compressDist.sh
 RUN ./.docker/compressDist.sh
 
-# Stage 3: Bundle the built application into a Docker container
+# Stage 2: Bundle the built application into a Docker container
 # which runs Nginx using Alpine Linux
-FROM nginxinc/nginx-unprivileged:1.27-alpine as final
+FROM nginxinc/nginx-unprivileged:1.27-alpine@sha256:65e3e85dbaed8ba248841d9d58a899b6197106c23cb0ff1a132b7bfe0547e4c0 AS final
 #RUN apk add --no-cache bash
 ARG PUBLIC_URL=/
 ENV PUBLIC_URL=${PUBLIC_URL}
@@ -90,16 +68,17 @@ ENV PORT=${PORT}
 RUN rm /etc/nginx/conf.d/default.conf
 USER nginx
 COPY --chown=nginx:nginx .docker/Viewer-v3.x /usr/src
-RUN chmod 777 /usr/src/entrypoint.sh
-COPY --from=builder /usr/src/app/platform/app/dist /usr/share/nginx/html${PUBLIC_URL}
+RUN chmod 755 /usr/src/entrypoint.sh
+COPY --chown=nginx:nginx --from=builder /usr/src/app/platform/app/dist /usr/share/nginx/html${PUBLIC_URL}
 # Copy paths that are renamed/redirected generally
 # Microscopy libraries depend on root level include, so must be copied
-COPY --from=builder /usr/src/app/platform/app/dist/dicom-microscopy-viewer /usr/share/nginx/html/dicom-microscopy-viewer
+COPY --chown=nginx:nginx --from=builder /usr/src/app/platform/app/dist/dicom-microscopy-viewer /usr/share/nginx/html/dicom-microscopy-viewer
 
-# In entrypoint.sh, app-config.js might be overwritten, so chmod it to be writeable.
-# The nginx user cannot chmod it, so change to root.
-USER root
-RUN chown -R nginx:nginx /usr/share/nginx/html && chmod -R 777 /usr/share/nginx/html
-USER nginx
+# app-config.js needs write permission for entrypoint.sh runtime override
+RUN chmod 664 /usr/share/nginx/html${PUBLIC_URL}app-config.js 2>/dev/null || true
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:${PORT}/ || exit 1
+
 ENTRYPOINT ["/usr/src/entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
Addresses 6 issues related to Docker security and build reproducibility.

## Changes
- Replace `chmod 777` with `755/664` for entrypoint and web root
- Make `QUICK_BUILD` a build arg defaulting to `false` for production
- Add security headers: X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy
- Add HSTS and TLS 1.2/1.3 hardening to SSL config
- Use `gzip -k` to keep original files alongside `.gz`
- Add `HEALTHCHECK` instruction
- Use `bun install --frozen-lockfile` for reproducible builds
- Pin base images by SHA256 digest
- Add `server_tokens off` and cache headers

## Issues
Closes #5, Closes #6, Closes #7, Closes #8, Closes #11, Closes #21