### PR TITLE
fix(typescript): enable strict TS flags, declare missing peerDep, strengthen ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,16 @@
   "rules": {
     // Enforce consistent brace style for all control statements for readability
     "curly": "error",
-    "import/no-anonymous-default-export": "off"
+    "import/no-anonymous-default-export": "off",
+    // Security: prevent eval and implied eval
+    "no-eval": "error",
+    "no-implied-eval": "error",
+    // Warn on explicit any to track and reduce usage over time
+    "@typescript-eslint/no-explicit-any": "warn",
+    // Warn on raw console.log to encourage structured logging
+    "no-console": ["warn", { "allow": ["warn", "error", "debug"] }],
+    // Prevent subtle re-render bugs from array index keys
+    "react/no-array-index-as-key": "warn"
   },
   "globals": {
     "cy": true,

--- a/extensions/cornerstone/package.json
+++ b/extensions/cornerstone/package.json
@@ -42,6 +42,7 @@
     "@cornerstonejs/codec-openjph": "2.4.7",
     "@cornerstonejs/dicom-image-loader": "4.22.3",
     "@ohif/core": "3.13.0-beta.67",
+    "@ohif/extension-default": "3.13.0-beta.67",
     "@ohif/ui": "3.13.0-beta.67",
     "dcmjs": "0.49.4",
     "dicom-parser": "1.8.21",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,9 @@
     "module": "esnext",
     "target": "ES2022",
     "outDir": "./dist",
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
     "paths": {
       "@ohif/core": ["platform/core/src"],
       "@ohif/ui": ["platform/ui/src"],


### PR DESCRIPTION
## Summary
Improves TypeScript strictness and ESLint rules.

## Changes
- Enable noImplicitReturns, noFallthroughCasesInSwitch, forceConsistentCasingInFileNames
- Add @ohif/extension-default as peerDependency of extension-cornerstone
- Add no-eval, no-implied-eval, @typescript-eslint/no-explicit-any, no-console, react/no-array-index-as-key rules

## Issues
Closes #12, Closes #13, Closes #18