### PR TITLE
test(modes): add unit tests for basic mode isValidMode

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
   projects: [
     '<rootDir>/platform/*/jest.config.js',
     '<rootDir>/extensions/*/jest.config.js',
-    //'<rootDir>/modes/*/jest.config.js' // Enable if any mode definitions start including tests
+    '<rootDir>/modes/*/jest.config.js',
   ],
   coverageDirectory: '<rootDir>/coverage/',
 };

--- a/modes/basic/jest.config.js
+++ b/modes/basic/jest.config.js
@@ -1,0 +1,7 @@
+const base = require('../../jest.config.base.js');
+
+module.exports = {
+  ...base,
+  displayName: 'mode-basic',
+  testMatch: ['<rootDir>/src/**/*.test.ts', '<rootDir>/src/**/*.test.tsx'],
+};

--- a/modes/basic/src/__tests__/isValidMode.test.ts
+++ b/modes/basic/src/__tests__/isValidMode.test.ts
@@ -1,0 +1,73 @@
+import { isValidMode, NON_IMAGE_MODALITIES } from '../index';
+
+describe('isValidMode', () => {
+  describe('with modeModalities defined', () => {
+    const context = {
+      modeModalities: ['CT', 'MR', 'PT', 'US', 'DX', 'CR', 'XA'],
+      nonModeModalities: NON_IMAGE_MODALITIES,
+    };
+
+    it('accepts a single supported modality', () => {
+      const result = isValidMode.call(context, { modalities: 'CT' });
+      expect(result.valid).toBe(true);
+    });
+
+    it('accepts multi-modality study with supported modality', () => {
+      const result = isValidMode.call(context, { modalities: 'CT\\PT' });
+      expect(result.valid).toBe(true);
+    });
+
+    it('rejects unsupported modality', () => {
+      const result = isValidMode.call(context, { modalities: 'UNKNOWN' });
+      expect(result.valid).toBe(false);
+    });
+
+    it('returns description on rejection', () => {
+      const result = isValidMode.call(context, { modalities: 'UNKNOWN' });
+      expect(result.description).toContain('None of the mode modalities match');
+    });
+  });
+
+  describe('with array modeModalities (multi-modality requirement)', () => {
+    const context = {
+      modeModalities: [['CT', 'PT'], 'MR'],
+      nonModeModalities: NON_IMAGE_MODALITIES,
+    };
+
+    it('accepts when all modalities in array are present', () => {
+      const result = isValidMode.call(context, { modalities: 'CT\\PT' });
+      expect(result.valid).toBe(true);
+    });
+
+    it('accepts single modality match', () => {
+      const result = isValidMode.call(context, { modalities: 'MR' });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('without modeModalities (fallback to nonModeModalities)', () => {
+    const context = {
+      nonModeModalities: NON_IMAGE_MODALITIES,
+    };
+
+    it('accepts study with imaging modality', () => {
+      const result = isValidMode.call(context, { modalities: 'CT' });
+      expect(result.valid).toBe(true);
+    });
+
+    it('rejects study with only non-imaging modalities', () => {
+      const result = isValidMode.call(context, { modalities: 'SEG' });
+      expect(result.valid).toBe(false);
+    });
+
+    it('accepts mixed study with at least one imaging modality', () => {
+      const result = isValidMode.call(context, { modalities: 'CT\\SEG' });
+      expect(result.valid).toBe(true);
+    });
+
+    it('rejects study with only SR and SEG', () => {
+      const result = isValidMode.call(context, { modalities: 'SR\\SEG' });
+      expect(result.valid).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds first unit tests for modes — previously at 0% coverage.

## Changes
- Add jest.config.js for modes/basic
- Add 10 test cases for isValidMode covering modality matching logic
- Enable modes in root jest.config.js

## Issues
Ref #16