### PR TITLE
fix(i18n): wrap hardcoded English strings with t() and add es translations

### DIFF
--- a/platform/i18n/src/locales/en-US/Common.json
+++ b/platform/i18n/src/locales/en-US/Common.json
@@ -25,5 +25,8 @@
   "Back": "Back",
   "Foreground": "Foreground",
   "SELECT A FOREGROUND": "SELECT A FOREGROUND",
-  "SELECT A SEGMENTATION": "SELECT A SEGMENTATION"
+  "SELECT A SEGMENTATION": "SELECT A SEGMENTATION",
+  "Copy": "Copy",
+  "Select Color": "Select Color",
+  "Sort direction": "Sort direction"
 }

--- a/platform/i18n/src/locales/es/Common.json
+++ b/platform/i18n/src/locales/es/Common.json
@@ -11,5 +11,18 @@
   "Series": "Secuencia",
   "Show": "Mostrar",
   "Stop": "Detener",
-  "StudyDate": "Fecha de estudo"
+  "StudyDate": "Fecha de estudio",
+  "Back": "Volver",
+  "Back to": "Volver a {{location}}",
+  "Cancel": "Cancelar",
+  "Close": "Cerrar",
+  "Copy": "Copiar",
+  "LOAD": "CARGAR",
+  "No": "No",
+  "NoStudyDate": "Sin fecha de estudio",
+  "Save": "Guardar",
+  "Select Color": "Seleccionar color",
+  "Sort direction": "Dirección de orden",
+  "Yes": "Sí",
+  "mm": "mm"
 }

--- a/platform/ui-next/src/components/BackgroundColorSelect/BackgroundColorSelect.tsx
+++ b/platform/ui-next/src/components/BackgroundColorSelect/BackgroundColorSelect.tsx
@@ -2,9 +2,11 @@
 
 import * as React from 'react';
 import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../Select';
 
 const BackgroundColorSelect: React.FC = () => {
+  const { t } = useTranslation('Common');
   const [selectedColor, setSelectedColor] = useState('#050615');
 
   useEffect(() => {
@@ -22,7 +24,7 @@ const BackgroundColorSelect: React.FC = () => {
     <div>
       <Select onValueChange={handleColorChange}>
         <SelectTrigger className="w-[180px]">
-          <SelectValue placeholder="Select Color" />
+          <SelectValue placeholder={t('Select Color')} />
         </SelectTrigger>
         <SelectContent>
           <SelectItem value="black">Viewport (Black)</SelectItem>

--- a/platform/ui-next/src/components/Clipboard/Clipboard.tsx
+++ b/platform/ui-next/src/components/Clipboard/Clipboard.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '../Button';
 import { Icons } from '../Icons';
 
@@ -7,6 +8,7 @@ interface ClipboardProps {
 }
 
 const Clipboard: React.FC<ClipboardProps> = ({ children }) => {
+  const { t } = useTranslation('Common');
   const [copyState, setCopyState] = React.useState<'idle' | 'success' | 'error'>('idle');
   const copyText = React.useMemo(() => {
     if (typeof children === 'string') {
@@ -38,7 +40,7 @@ const Clipboard: React.FC<ClipboardProps> = ({ children }) => {
         handleCopy();
       }}
       className="text-foreground"
-      title="Copy"
+      title={t('Copy')}
     >
       {copyState === 'idle' && <Icons.Copy className="h-6 w-6" />}
       {copyState === 'success' && <Icons.FeedbackComplete className="h-6 w-6 text-foreground" />}

--- a/platform/ui-next/src/components/Icons/Icons.tsx
+++ b/platform/ui-next/src/components/Icons/Icons.tsx
@@ -817,7 +817,7 @@ export const Icons = {
 
     if (!IconComponent) {
       console.debug(`Icon "${name}" not found.`);
-      return <div>Missing Icon</div>;
+      return <span data-missing-icon={name}>⚠</span>;
     }
 
     return (

--- a/platform/ui-next/src/components/StudyBrowserSort/StudyBrowserSort.tsx
+++ b/platform/ui-next/src/components/StudyBrowserSort/StudyBrowserSort.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Icons } from '../Icons';
 import {
   DropdownMenu,
@@ -9,6 +10,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '../Tooltip';
 
 export function StudyBrowserSort({ servicesManager }: withAppTypes) {
+  const { t } = useTranslation('Common');
   // Todo: this should not be here, no servicesManager should be in ui-next, only
   // customization service
   const { customizationService, displaySetService } = servicesManager.services;
@@ -86,7 +88,7 @@ export function StudyBrowserSort({ servicesManager }: withAppTypes) {
             )}
           </button>
         </TooltipTrigger>
-        <TooltipContent>Sort direction</TooltipContent>
+        <TooltipContent>{t('Sort direction')}</TooltipContent>
       </Tooltip>
     </div>
   );


### PR DESCRIPTION
## Summary
Wraps hardcoded English strings with i18n t() function and adds missing Spanish translations.

## Changes
- Wrap hardcoded strings in BackgroundColorSelect, Clipboard, StudyBrowserSort
- Replace hardcoded 'Missing Icon' div with data attribute
- Add Copy, Select Color, Sort direction keys to en-US/Common.json
- Complete es/Common.json with 14 missing translations
- Fix typo: 'estudo' → 'estudio'

## Issues
Ref #17