### PR TITLE
feat(core): detect DICOM files via magic bytes for drag-and-drop

### DIFF
--- a/platform/app/src/routes/Local/filesToStudies.js
+++ b/platform/app/src/routes/Local/filesToStudies.js
@@ -1,8 +1,18 @@
 import FileLoaderService from './fileLoaderService';
-import { DicomMetadataStore } from '@ohif/core';
+import { DicomMetadataStore, utils } from '@ohif/core';
+
+const { isDicomFile } = utils;
 
 const processFile = async file => {
   try {
+    // Skip non-DICOM files (PDF handled separately by fileLoaderService)
+    if (file.type !== 'application/pdf') {
+      const isDicom = await isDicomFile(file);
+      if (!isDicom) {
+        return;
+      }
+    }
+
     const fileLoaderService = new FileLoaderService(file);
     const imageId = fileLoaderService.addFile(file);
     const image = await fileLoaderService.loadFile(file, imageId);
@@ -10,7 +20,7 @@ const processFile = async file => {
 
     DicomMetadataStore.addInstance(dicomJSONDataset);
   } catch (error) {
-    console.log(error.name, ':Error when trying to load and process local files:', error.message);
+    console.debug(error.name, ':Error when trying to load and process local files:', error.message);
   }
 };
 

--- a/platform/core/src/utils/index.ts
+++ b/platform/core/src/utils/index.ts
@@ -12,6 +12,7 @@ import makeCancelable from './makeCancelable';
 import hotkeys from './hotkeys';
 import Queue from './Queue';
 import isDicomUid from './isDicomUid';
+import { isDicomFile, isDicomBuffer } from './isDicomFile';
 import formatDate from './formatDate';
 import formatTime from './formatTime';
 import formatPN from './formatPN';
@@ -82,6 +83,8 @@ const utils = {
   hotkeys,
   Queue,
   isDicomUid,
+  isDicomFile,
+  isDicomBuffer,
   isEqualWithin,
   sopClassDictionary,
   addAccessors,
@@ -125,6 +128,8 @@ export {
   hotkeys,
   Queue,
   isDicomUid,
+  isDicomFile,
+  isDicomBuffer,
   isEqualWithin,
   resolveObjectPath,
   hierarchicalListUtils,

--- a/platform/core/src/utils/isDicomFile.ts
+++ b/platform/core/src/utils/isDicomFile.ts
@@ -1,0 +1,72 @@
+/**
+ * Detect whether a file or ArrayBuffer contains DICOM data by checking magic bytes.
+ *
+ * A standard DICOM file has a 128-byte preamble followed by "DICM" at offset 128.
+ * Some legacy DICOM files lack the preamble — these start directly with a DICOM
+ * tag (commonly group 0008, element 0005 for SpecificCharacterSet).
+ */
+
+const DICM_PREFIX_OFFSET = 128;
+const DICM_BYTES = [0x44, 0x49, 0x43, 0x4d]; // "DICM"
+
+/**
+ * Check if an ArrayBuffer contains DICOM data via magic bytes.
+ */
+export function isDicomBuffer(buffer: ArrayBuffer): boolean {
+  if (buffer.byteLength <= DICM_PREFIX_OFFSET + 4) {
+    return isDicomWithoutPreamble(buffer);
+  }
+
+  const view = new Uint8Array(buffer, DICM_PREFIX_OFFSET, 4);
+  if (DICM_BYTES.every((b, i) => view[i] === b)) {
+    return true;
+  }
+
+  return isDicomWithoutPreamble(buffer);
+}
+
+/**
+ * Check for DICOM without standard preamble (implicit VR little-endian).
+ * Looks for common first tag: (0008,0005) SpecificCharacterSet or (0008,0008) ImageType
+ * or (0002,0000) FileMetaInformationGroupLength.
+ */
+function isDicomWithoutPreamble(buffer: ArrayBuffer): boolean {
+  if (buffer.byteLength < 4) {
+    return false;
+  }
+
+  const view = new DataView(buffer);
+  const group = view.getUint16(0, true);
+  const element = view.getUint16(2, true);
+
+  // Common first tags in DICOM files without preamble
+  return (
+    (group === 0x0002 && element === 0x0000) || // FileMetaInformationGroupLength
+    (group === 0x0002 && element === 0x0001) || // FileMetaInformationVersion
+    (group === 0x0008 && element === 0x0005) || // SpecificCharacterSet
+    (group === 0x0008 && element === 0x0008) // ImageType
+  );
+}
+
+/**
+ * Check if a File object is a DICOM file by reading its first 132 bytes.
+ */
+export async function isDicomFile(file: File): Promise<boolean> {
+  // Known DICOM MIME types
+  if (file.type === 'application/dicom' || file.type === 'application/dcm') {
+    return true;
+  }
+
+  // Known DICOM extensions
+  const ext = file.name.split('.').pop()?.toLowerCase();
+  if (ext === 'dcm' || ext === 'dicom') {
+    return true;
+  }
+
+  // Read first 132 bytes for magic byte detection
+  const slice = file.slice(0, DICM_PREFIX_OFFSET + 4);
+  const buffer = await slice.arrayBuffer();
+  return isDicomBuffer(buffer);
+}
+
+export default isDicomFile;


### PR DESCRIPTION
## Summary
Adds DICOM file detection via magic bytes, integrated into the drag-and-drop pipeline.

## Changes
- New `isDicomFile()` async utility checking DICM magic bytes at offset 128
- New `isDicomBuffer()` sync utility for ArrayBuffer detection
- Support for files without preamble (implicit VR little-endian)
- Integrated into `filesToStudies.js` to filter non-DICOM files on drop
- Exported from `@ohif/core` utils

## Issues
Closes #29