### PR TITLE
feat(core): add AuditTrailService for HIPAA/IHE ATNA compliance

### DIFF
--- a/platform/app/src/appInit.js
+++ b/platform/app/src/appInit.js
@@ -21,6 +21,7 @@ import {
   WorkflowStepsService,
   StudyPrefetcherService,
   MultiMonitorService,
+  AuditTrailService,
   // utils,
 } from '@ohif/core';
 
@@ -78,6 +79,7 @@ async function appInit(appConfigOrFunc, defaultExtensions, defaultModes) {
     PanelService.REGISTRATION,
     WorkflowStepsService.REGISTRATION,
     [StudyPrefetcherService.REGISTRATION, appConfig.studyPrefetcher],
+    [AuditTrailService.REGISTRATION, appConfig.auditTrail],
   ]);
 
   errorHandler.getHTTPErrorHandler = () => {

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -35,6 +35,7 @@ import {
   WorkflowStepsService,
   StudyPrefetcherService,
   MultiMonitorService,
+  AuditTrailService,
 } from './services';
 
 import { DisplaySetMessage, DisplaySetMessageList } from './services/DisplaySetService';
@@ -83,6 +84,7 @@ const OHIF = {
   HangingProtocolService,
   UserAuthenticationService,
   MultiMonitorService,
+  AuditTrailService,
   IWebApiDataSource,
   DicomMetadataStore,
   pubSubServiceInterface,
@@ -130,6 +132,7 @@ export {
   ViewportGridService,
   HangingProtocolService,
   UserAuthenticationService,
+  AuditTrailService,
   IWebApiDataSource,
   DicomMetadataStore,
   pubSubServiceInterface,

--- a/platform/core/src/services/AuditTrailService/AuditTrailService.ts
+++ b/platform/core/src/services/AuditTrailService/AuditTrailService.ts
@@ -1,0 +1,138 @@
+import { PubSubService } from '../_shared/pubSubServiceInterface';
+
+export type AuditEvent = {
+  timestamp: string;
+  eventType: string;
+  userId?: string;
+  userName?: string;
+  details: Record<string, unknown>;
+};
+
+type AuditBackend = (event: AuditEvent) => void;
+
+/**
+ * AuditTrailService — logs clinical actions for HIPAA/IHE ATNA compliance.
+ *
+ * Tracks: study access, measurement CRUD, annotations, exports, auth events.
+ * Events are emitted to configurable backends (console, HTTP, custom).
+ */
+class AuditTrailService extends PubSubService {
+  public static readonly EVENTS = {
+    AUDIT_EVENT_LOGGED: 'event::auditEventLogged',
+  };
+
+  public static REGISTRATION = {
+    name: 'auditTrailService',
+    altName: 'AuditTrailService',
+    create: ({ configuration = {} }) => {
+      return new AuditTrailService(configuration);
+    },
+  };
+
+  private _enabled: boolean;
+  private _backends: AuditBackend[];
+  private _userId: string | null;
+  private _userName: string | null;
+  private _httpEndpoint: string | null;
+
+  constructor(configuration: Record<string, unknown> = {}) {
+    super(AuditTrailService.EVENTS);
+    this._enabled = (configuration.enabled as boolean) ?? false;
+    this._httpEndpoint = (configuration.httpEndpoint as string) ?? null;
+    this._backends = [];
+    this._userId = null;
+    this._userName = null;
+
+    // Default backend: structured console logging
+    this._backends.push((event: AuditEvent) => {
+      console.debug('[AUDIT]', JSON.stringify(event));
+    });
+
+    // HTTP backend if configured
+    if (this._httpEndpoint) {
+      this._backends.push((event: AuditEvent) => {
+        fetch(this._httpEndpoint!, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(event),
+          keepalive: true,
+        }).catch(() => {});
+      });
+    }
+  }
+
+  public setUser(userId: string, userName?: string): void {
+    this._userId = userId;
+    this._userName = userName ?? null;
+  }
+
+  public addBackend(backend: AuditBackend): void {
+    this._backends.push(backend);
+  }
+
+  public log(eventType: string, details: Record<string, unknown> = {}): void {
+    if (!this._enabled) {
+      return;
+    }
+
+    const event: AuditEvent = {
+      timestamp: new Date().toISOString(),
+      eventType,
+      userId: this._userId ?? undefined,
+      userName: this._userName ?? undefined,
+      details,
+    };
+
+    this._backends.forEach(backend => {
+      try {
+        backend(event);
+      } catch {
+        // Never let audit logging break the application
+      }
+    });
+
+    this._broadcastEvent(AuditTrailService.EVENTS.AUDIT_EVENT_LOGGED, event);
+  }
+
+  // Convenience methods for common clinical events
+
+  public logStudyAccess(
+    studyInstanceUID: string,
+    action: 'open' | 'close',
+    extra: Record<string, unknown> = {}
+  ): void {
+    this.log('STUDY_ACCESS', { studyInstanceUID, action, ...extra });
+  }
+
+  public logMeasurement(
+    action: 'create' | 'update' | 'delete',
+    measurement: Record<string, unknown>
+  ): void {
+    this.log('MEASUREMENT', {
+      action,
+      measurementUID: measurement.uid,
+      toolType: measurement.toolName,
+      label: measurement.label,
+      studyInstanceUID: measurement.referenceStudyUID,
+      seriesInstanceUID: measurement.referenceSeriesUID,
+    });
+  }
+
+  public logExport(format: string, studyInstanceUID: string): void {
+    this.log('EXPORT', { format, studyInstanceUID });
+  }
+
+  public logAuthentication(action: 'login' | 'logout'): void {
+    this.log('AUTHENTICATION', { action });
+  }
+
+  public logViewportAction(
+    action: string,
+    viewportId: string,
+    details: Record<string, unknown> = {}
+  ): void {
+    this.log('VIEWPORT_ACTION', { action, viewportId, ...details });
+  }
+}
+
+export default AuditTrailService;

--- a/platform/core/src/services/AuditTrailService/index.ts
+++ b/platform/core/src/services/AuditTrailService/index.ts
@@ -1,0 +1,4 @@
+import AuditTrailService from './AuditTrailService';
+
+export default AuditTrailService;
+export type { AuditEvent } from './AuditTrailService';

--- a/platform/core/src/services/index.ts
+++ b/platform/core/src/services/index.ts
@@ -18,6 +18,7 @@ import PanelService from './PanelService';
 import WorkflowStepsService from './WorkflowStepsService';
 import StudyPrefetcherService from './StudyPrefetcherService';
 import { MultiMonitorService } from './MultiMonitorService';
+import AuditTrailService from './AuditTrailService';
 
 import type Services from '../types/Services';
 
@@ -44,4 +45,5 @@ export {
   PanelService,
   WorkflowStepsService,
   StudyPrefetcherService,
+  AuditTrailService,
 };


### PR DESCRIPTION
## Summary
New audit trail service for clinical compliance.

## Changes
- AuditTrailService with PubSubService pattern
- Logs: study access, measurement CRUD, exports, auth, viewport actions
- Console + HTTP backends, configurable via appConfig.auditTrail
- Registered in appInit

## Regulatory
HIPAA 45 CFR §164.312(b), FDA 21 CFR Part 11, IHE ATNA

## Issues
Closes #44