### PR TITLE
feat(cornerstone): complete W/L presets for MR, CR/DX, MG, US, NM

### DIFF
--- a/extensions/cornerstone/src/components/WindowLevelActionMenu/defaultWindowLevelPresets.ts
+++ b/extensions/cornerstone/src/components/WindowLevelActionMenu/defaultWindowLevelPresets.ts
@@ -18,6 +18,42 @@ const defaultWindowLevelPresets = {
     { id: 'pt-suv-10', description: 'SUV', window: '0', level: '10' },
     { id: 'pt-suv-15', description: 'SUV', window: '0', level: '15' },
   ],
+
+  MR: [
+    { id: 'mr-default', description: 'Default', window: '400', level: '200' },
+    { id: 'mr-t1', description: 'T1', window: '500', level: '250' },
+    { id: 'mr-t2', description: 'T2', window: '600', level: '300' },
+    { id: 'mr-flair', description: 'FLAIR', window: '1200', level: '600' },
+    { id: 'mr-dwi', description: 'DWI', window: '1000', level: '500' },
+  ],
+
+  CR: [
+    { id: 'cr-chest', description: 'Chest', window: '2048', level: '1024' },
+    { id: 'cr-bone', description: 'Bone', window: '4096', level: '2048' },
+    { id: 'cr-abdomen', description: 'Abdomen', window: '1024', level: '512' },
+  ],
+
+  DX: [
+    { id: 'dx-chest', description: 'Chest', window: '2048', level: '1024' },
+    { id: 'dx-bone', description: 'Bone', window: '4096', level: '2048' },
+    { id: 'dx-abdomen', description: 'Abdomen', window: '1024', level: '512' },
+  ],
+
+  MG: [
+    { id: 'mg-standard', description: 'Standard', window: '2048', level: '1024' },
+    { id: 'mg-enhanced', description: 'Enhanced', window: '4096', level: '2048' },
+    { id: 'mg-dense', description: 'Dense tissue', window: '1024', level: '512' },
+  ],
+
+  US: [
+    { id: 'us-default', description: 'Default', window: '256', level: '128' },
+    { id: 'us-msk', description: 'Musculoskeletal', window: '200', level: '100' },
+  ],
+
+  NM: [
+    { id: 'nm-default', description: 'Default', window: '256', level: '128' },
+    { id: 'nm-bone-scan', description: 'Bone Scan', window: '512', level: '256' },
+  ],
 };
 
 export default defaultWindowLevelPresets;


### PR DESCRIPTION
## Summary
Adds missing W/L presets for clinical modalities.

## Changes
- MR: Default, T1, T2, FLAIR, DWI (5 presets)
- CR: Chest, Bone, Abdomen (3 presets)
- DX: Chest, Bone, Abdomen (3 presets)
- MG: Standard, Enhanced, Dense tissue (3 presets)
- US: Default, Musculoskeletal (2 presets)
- NM: Default, Bone Scan (2 presets)

## Issues
Closes #47